### PR TITLE
Configurable list of available log files to monitor

### DIFF
--- a/app/controllers/browserlog/logs_controller.rb
+++ b/app/controllers/browserlog/logs_controller.rb
@@ -11,7 +11,7 @@ module Browserlog
     end
 
     def changes
-      lines, last_line_number = reader.read(offset: params[:currentLine].to_i)
+      lines, last_line_number = reader.read(offset: params[:currentLine].to_i, log_file_name: params[:env])
 
       respond_to do |format|
         format.json do
@@ -34,7 +34,7 @@ module Browserlog
     end
 
     def check_env
-      fail unless %w(test development staging production).include?(params[:env])
+      fail unless Browserlog.config.allowed_log_files.include?(params[:env])
     end
 
     def check_auth

--- a/lib/browserlog/config.rb
+++ b/lib/browserlog/config.rb
@@ -4,10 +4,11 @@ module Browserlog
   class Config
     include Singleton
 
-    attr_accessor :allow_production_logs
+    attr_accessor :allow_production_logs, :allowed_log_files
 
     def initialize
       @allow_production_logs = false
+      @allowed_log_files = %w(test development production)
     end
   end
 end

--- a/lib/browserlog/log_reader.rb
+++ b/lib/browserlog/log_reader.rb
@@ -4,6 +4,7 @@ module Browserlog
       offset = options[:offset] || -1
       limit = options[:limit] || 25
       amount = [limit, remaining_lines(offset)].min
+      @log_file_name = options[:log_file_name] || 'development'
 
       if offset == -1
         line_index = num_lines
@@ -21,7 +22,7 @@ module Browserlog
     end
 
     def log_path
-      Rails.root.join("log/#{Rails.env}.log")
+      Rails.root.join("log/#{@log_file_name}.log")
     end
 
     def num_lines

--- a/lib/browserlog/log_reader.rb
+++ b/lib/browserlog/log_reader.rb
@@ -1,11 +1,10 @@
 module Browserlog
   class LogReader
     def read(options = {})
+      @log_file_name = options[:log_file_name] || 'development'
       offset = options[:offset] || -1
       limit = options[:limit] || 25
       amount = [limit, remaining_lines(offset)].min
-      @log_file_name = options[:log_file_name] || 'development'
-
       if offset == -1
         line_index = num_lines
         [readlines(amount), line_index]


### PR DESCRIPTION
Sometimes you need not only development/test/production logs.
Now you can set initializer like: Browserlog.config.allowed_log_files << "resque" to allow resque.log monitoring.